### PR TITLE
Mapa de trajeto tem feature novo que renderiza a area não percirrida da rota vinculada ao trajeto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@tailwindcss/vite": "^4.1.12",
         "@tanstack/react-query": "^5.87.1",
         "@tanstack/react-table": "^8.21.3",
+        "@turf/turf": "^7.3.1",
         "@types/leaflet": "^1.9.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -180,6 +181,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -715,6 +717,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -758,6 +761,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3121,6 +3125,2032 @@
         "typescript": ">=5.7.2"
       }
     },
+    "node_modules/@turf/along": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-7.3.1.tgz",
+      "integrity": "sha512-z84b9PKsUB69BhkeHA6oPqRO7VaJHwTid1SpuIbwWzDqHTpq8buJBKlrKgHIIthuVr5P/AZiEXmf3R4ifRhDmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.1",
+        "@turf/destination": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/angle": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/angle/-/angle-7.3.1.tgz",
+      "integrity": "sha512-Pcb0Fg8WHsOMKFvIPaYfORrlLYdytWjVAkVTnAqJdmGI+2n+eLROPjJO2sJbpX9yU/dlBgujOB7a1d0PJjhHyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/rhumb-bearing": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.1.tgz",
+      "integrity": "sha512-9nSiwt4zB5QDMcSoTxF28WpK1f741MNKcpUJDiHVRX08CZ4qfGWGV9ZIPQ8TVEn5RE4LyYkFuQ47Z9pdEUZE9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.1.tgz",
+      "integrity": "sha512-/IyMKoS7P9B0ch5PIlQ6gMfoE8gRr48+cSbzlyexvEjuDuaAV1VURjH1jAthS0ipFG8RrFxFJKnp7TLL1Skong==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-clip": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-7.3.1.tgz",
+      "integrity": "sha512-YUeITFtp5QLbpSS0XyQa0GlgMqK4PMgjOeOGOTlWsfDYaqc5SErf7o5UyCOsLAPQW16QZVxJ26uTAE20YkluAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox-polygon": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-7.3.1.tgz",
+      "integrity": "sha512-2NvwPfuRtwJk7w5HIC/Knei3mUXrVT+t/0FB1zStgDbakmXrqKISaftlIh4YTOVlUsVnvq0tggjFMLZ/Xxo+lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-7.3.1.tgz",
+      "integrity": "sha512-ex78l/LiY6uO6jO8AJepyWE6/tiWEbXjKLOgqUfJSkW23UcMVlhbAKzXDjbsdz9T66sXFC/6QNAh8oaZzmoo6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bezier-spline": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-7.3.1.tgz",
+      "integrity": "sha512-7Mal/d8ttTQ5eu/mwgC53iH9eYBRTBHXsIqEEiTVHChh1iajNuS4/bwYdaxsQsRXKVaFfx+4dCy0cRmqhjgTrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-clockwise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-7.3.1.tgz",
+      "integrity": "sha512-ik9j0CCrsp/JZ42tbCnyZg86YFoavEU/nyal3HsEgdY5WFYq43aMYqLPRi6yNqE48THEk3fl1BcfgJqAiUhDFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-concave": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-concave/-/boolean-concave-7.3.1.tgz",
+      "integrity": "sha512-jAAt5MhqXSKmRmX7l09oeo9dObf7bMDuzfeUSSNAK+yAi9TE5QWlP4JtzOWC5+gKXsL8dvzE8mvsQj38FzQdEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-contains": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-7.3.1.tgz",
+      "integrity": "sha512-VvytV9ZcUgnitzm5ILVWIoOhoZOh8VZ4dnweUJM3N+A77CzXXFk8e4NqPNZ6tZVPY3ehxzDXrq1+iN87pMcB7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/boolean-point-on-line": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-crosses": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-7.3.1.tgz",
+      "integrity": "sha512-Fn99AxTXQORiQjclUqUYQcA40oJJoJxMBFx/Vycd7v949Lnplt1qrUkBpbZNXQlvHF2gxrgirSfgBDaUnUJjzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/line-intersect": "7.3.1",
+        "@turf/polygon-to-line": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-7.3.1.tgz",
+      "integrity": "sha512-bqVo+eAYaCq0lcr09zsZdWIAdv22UzGc/h2CCfaBwP5r4o/rFudNFLU9gb9BcM6dBUzrtTgBguShAZr7k3cGbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/line-intersect": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/polygon-to-line": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-equal": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-7.3.1.tgz",
+      "integrity": "sha512-nEsmmNdwD1nzYZLsO6hPC/X/Uag+eT0yuWamD0XxJAQhXBsnSATxKisCJXVJgXvO8M0qvEMW1zZrUGB6Fjfzzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-7.3.1.tgz",
+      "integrity": "sha512-nc6W8qFdzFkfsR6p506HINGu85nHk/Skm+cw3TRQZ5/A44hjf0kYnbhvS3qrCAws3bR+/FKK8O1bsO/Udk8kkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-disjoint": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-overlap": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-7.3.1.tgz",
+      "integrity": "sha512-QhhsgCLzkwXIeZhaCmgE3H8yTANJGZatJ5IzQG3xnPTx7LiNAaa/ReN2/NroEv++8Yc0sr5Bkh6xWZOtew1dvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/line-intersect": "7.3.1",
+        "@turf/line-overlap": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "geojson-equality-ts": "^1.0.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-parallel": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-7.3.1.tgz",
+      "integrity": "sha512-SXPyYiuaRB1ES/LtcUP11HWyloMJGzN1nYaCLG7H+6l2OKjVJl025qR6uxVElWCzAdElek9nGNeNya1hd9ZHaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/line-segment": "7.3.1",
+        "@turf/rhumb-bearing": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.3.1.tgz",
+      "integrity": "sha512-BUPW63vE43LctwkgannjmEFTX1KFR/18SS7WzFahJWK1ZoP0s1jrfxGX+pi0BH/3Dd9mA71hkGKDDnj1Ndcz0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-on-line": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-7.3.1.tgz",
+      "integrity": "sha512-8Hywuv7XFpSc8nfH0BJBtt+XTcJ7OjfjpX2Sz+ty8gyiY/2nCLLqq6amu3ebr67ruqZTDpPNQoGGUbUePjF3rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-touches": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-touches/-/boolean-touches-7.3.1.tgz",
+      "integrity": "sha512-XqrQzYGTakoTWeTWT274pfObpbIpAM7L8CzGUa04rJD0l3bv3VK4TUw0v6+bywi5ea6TnJzvOzgvzTb1DtvBKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/boolean-point-on-line": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-valid": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-valid/-/boolean-valid-7.3.1.tgz",
+      "integrity": "sha512-lpw4J5HaV4Tv033s2j/i6QHt6Zx/8Lc90DTfOU0axgRSrs127kbKNJsmDEGvtmV7YjNp8aPbIG1wwAX9wg/dMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/boolean-crosses": "7.3.1",
+        "@turf/boolean-disjoint": "7.3.1",
+        "@turf/boolean-overlap": "7.3.1",
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/boolean-point-on-line": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/line-intersect": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "geojson-polygon-self-intersections": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-within": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-7.3.1.tgz",
+      "integrity": "sha512-oxP4VU81RRCf59TXCBhVWEyJ5Lsr+wrqvqSAFxyBuur5oLmBqZdYyvL7FQJmYvG0uOxX7ohyHmSJMaTe4EhGDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/boolean-point-on-line": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-7.3.1.tgz",
+      "integrity": "sha512-jtdI0Ir3GwPyY1V2dFX039HNhD8MIYLX39c7b9AZdLh7kBuD2VgXJmPvhtnivqMV2SmRlS4fd9cKzNj369/cGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/center": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/jsts": "^2.7.1",
+        "@turf/meta": "7.3.1",
+        "@turf/projection": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "d3-geo": "1.7.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-7.3.1.tgz",
+      "integrity": "sha512-czqNKLGGdik3phYsWCK5SHKBRkDulUArMlG4v62IQcNcRFq9MbOGqyN21GSshSMO792ynDeWzdXdcKmycQ14Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-mean": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-7.3.1.tgz",
+      "integrity": "sha512-koVenhCl8JPEvtDwH6nhZpLAm9+7XOXosqKdkXyK1uDae3NRyoQQeIYD7nIJHJPCOyeacw6buWzAEoAleBj0XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-median": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-7.3.1.tgz",
+      "integrity": "sha512-XIvxqnSdcUFOev4WO8AEQth4U3uzfQkxYVkKhZrxpVitqEeSDm5v3ANUeVGYqQ/QNTWvFAFn4zB5+XRRd8tayA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.1",
+        "@turf/centroid": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center-of-mass": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-7.3.1.tgz",
+      "integrity": "sha512-w2O7RLc0tSs+eEsZCaWa1lYiACsaQTJtie/a4bj5ta1TDTAEjyxC6Rp6br4mN1XPzeSFbEuNw+q9/VdSXU/mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.1",
+        "@turf/convex": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.1.tgz",
+      "integrity": "sha512-hRnsDdVBH4pX9mAjYympb2q5W8TCMUMNEjcRrAF7HTCyjIuRmjJf8vUtlzf7TTn9RXbsvPc1vtm3kLw20Jm8DQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/circle": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-7.3.1.tgz",
+      "integrity": "sha512-UY2OM1OK7IuyrtN3YE8026ZM3xM9VIkqZ0vRZln8g33D0AogrJVJ/I9T81/VpRPlxTnrbDpzQxJQBH+3vPG/Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clean-coords": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-7.3.1.tgz",
+      "integrity": "sha512-uNo4lnTekvkw8dUCXIVCc38nZiHBrpy5jn0T8hlodZo/A4XAChFtLQi8NLcX8rtXcaNxeJo+yaPfpP3PSVI2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-7.3.1.tgz",
+      "integrity": "sha512-r7xDOfw9ohA7PhZW+8X9RMsO4szB4YqkhEROaELJyLtQ1bo8VNFtndpZdE6YHQpD7Pjlvlb6i99q8w1QLisEPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-7.3.1.tgz",
+      "integrity": "sha512-ZELehyYnsozw+AHOc426abmPaGJOt46BHnCN+hwtPOkqEbvdZYu+16Y+cjiFnY7FwbvzBjDMb9HRtKJFlAmupg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-dbscan": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-7.3.1.tgz",
+      "integrity": "sha512-rY1wbQlljRhX5e+XM/yw4dKs2HniN45v+Xf5Xde6nv23WyEf/LLjpyD5yrsLa1awfJjD/NmD6axGVebnBBn9YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clusters-kmeans": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-7.3.1.tgz",
+      "integrity": "sha512-HYvRninBY/b5ftkIkoVWjV/wHilNE56cdr6gTlrxuvm4EClilsLDSVYjeiMYU0pjI3xDTc7PlicQDGdnIavUqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "skmeans": "0.9.7",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/collect": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-7.3.1.tgz",
+      "integrity": "sha512-yVDz5YLcRGFipttb60Y4IAd7zWfbQk6mNW5Kt6/wa8+YueHFzsKJdtbErWfozCVuiKplQZWT5r+9J9g6RnhpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/combine": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-7.3.1.tgz",
+      "integrity": "sha512-iZBe36sKRq08fY3Ars0JpfYJm8N3LtLLnNzdTxHp8Ry2ORJGHvZHpcv3lQXWL7gyJwDPAye7pyrX7S99IB/1VA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/concave": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-7.3.1.tgz",
+      "integrity": "sha512-vZWqyAYH4qzOuiqPb+bj2jvpIGzYAH8byUhfFJ2gRFRL3/RfV8jdXL2r0Y6VFScqE6OLVGvtM3ITzXX1/9wTaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/tin": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "topojson-client": "3.x",
+        "topojson-server": "3.x",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/convex": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-7.3.1.tgz",
+      "integrity": "sha512-k2T8QVSie4w+KhwUxjzi/6S6VFr33H9gnUawOh4chCGAgje9PljUZLCGbktHgDfAjX1FVzyUyriH+dm86Z7njQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "concaveman": "^1.2.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-7.3.1.tgz",
+      "integrity": "sha512-yyiJtbQJ4AB9Ny/FKDDNuWI9Sg4Jtd2PMpQPqOV3AFq8NNkg0xJSNmDHDxupb3oPqPWYPxyfVI3tBoF+Xhhoig==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/difference": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-7.3.1.tgz",
+      "integrity": "sha512-Ne2AR+1AdeH8aqY2VHcws+Z/1MHl8SlSbSWHBNVZUVEfvyzTrRg8/E+OC5vFaSUvNZXkB/OUufTCM9xsatLKXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/dissolve": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-7.3.1.tgz",
+      "integrity": "sha512-Xmjl4E1aGRMdJjq+HfsiAXZtfMKruq7O+8xvsqnHM6E8iBWlJNSw8ucrNB5RZME8BUojx0q8bvXgS3k68koGyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/flatten": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-7.3.1.tgz",
+      "integrity": "sha512-DK//doTGgYYjBkcWUywAe7wbZYcdP97hdEJ6rXYVYRoULwGGR3lhY96GNjozg6gaW9q2eSNYnZLpcL5iFVHqgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance-weight": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/distance-weight/-/distance-weight-7.3.1.tgz",
+      "integrity": "sha512-h82qLPeMxOfgN62ZysscQCu9IYB5AO+duw7peAQnMtFobpbcQK58158P0cNzxAoTVJXSO/mfR9dI9Zdz7NF75w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/ellipse": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-7.3.1.tgz",
+      "integrity": "sha512-tcGbS+U7EktZg+UJad17LRU+8C067XDWdmURPCmycaib2zRxeNrImh2Y/589us6wsldlYYoBYRxDY/c1oxIUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/destination": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/transform-rotate": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/envelope": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-7.3.1.tgz",
+      "integrity": "sha512-Sp3ct/LpWyHN5tTfPOcKXFoVDI1QH9BXtQ+aQzABFp3U5nY2Sz8LFg8SeFQm3K7PpoCnUwSfwDFA4aa+z+4l1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/bbox-polygon": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/explode": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-7.3.1.tgz",
+      "integrity": "sha512-H0Q8NnmrPoWKhsYYmVmkuT5F4t50N53ByGBf6Ys1n5B9YrFyrT+/aLDXF2C05r+QnW8nFtkM4lFG3ZSBHiq4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flatten": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-7.3.1.tgz",
+      "integrity": "sha512-cM/uuQP8oZ4IDJG342uOlqQ8yD9RsAY9Gg9nsDOgJn6tN065aigRCNy2lfrNyLdK/CPTVEWQzx1EQa+zXGSgAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/flip": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-7.3.1.tgz",
+      "integrity": "sha512-6sF41pWY8Tw7w72hYc87sR9zzDei7UZ4Db/z0mKuNKueyzl4iTQ/H2JVd/XLZ7Tasz7H8htmrbUO0GR8GY7qiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/geojson-rbush": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/geojson-rbush/-/geojson-rbush-7.3.1.tgz",
+      "integrity": "sha512-EsrBBftZS5TvzRP2opLzwfnPXfmJi45KkGUcKSSFD0bxQe3BQUSmBrZbHMT8avB2s/XHrS/MniqsyeVOMwc35Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/great-circle": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-7.3.1.tgz",
+      "integrity": "sha512-pfs7PzBRgYEEyecM0ni6iEF19grn9FmbHyaLz7voYInmc2ZHfWQaxuY4dcf9cziWDaiPlbuyr/RyE6envg1xpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.1.tgz",
+      "integrity": "sha512-zkL34JVhi5XhsuMEO0MUTIIFEJ8yiW1InMu4hu/oRqamlY4mMoZql0viEmH6Dafh/p+zOl8OYvMJ3Vm3rFshgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/hex-grid": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-7.3.1.tgz",
+      "integrity": "sha512-cWAKxlU1aa06976C3RhpcilDzLnWwXkH/atNIWKGpLV/HubHrMXxhp9VMBKWaqsLbdn5x2uJjv4MxwWw9/373g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/intersect": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/interpolate": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-7.3.1.tgz",
+      "integrity": "sha512-dquwDplzkSANMQdvxAu0dRF69EBIIlW/1zTPOB/BQfb/s7j6t8RskgbuV8ew1KpJPMmj7EbexejiMBtRWXTu4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/centroid": "7.3.1",
+        "@turf/clone": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/hex-grid": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/point-grid": "7.3.1",
+        "@turf/square-grid": "7.3.1",
+        "@turf/triangle-grid": "7.3.1",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/intersect": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-7.3.1.tgz",
+      "integrity": "sha512-676688YnF9wpprMioQWvxPlUMhtTvYITzw4XoG3lQmLjd/yt2cByanQHWpzWauLfYUlfuL13AeRGdqXRhSkhTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.3.1.tgz",
+      "integrity": "sha512-IdZJfDjIDCLH+Gu2yLFoSM7H23sdetIo5t4ET1/25X8gi3GE2XSqbZwaGjuZgNh02nisBewLqNiJs2bo+hrqZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isobands": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-7.3.1.tgz",
+      "integrity": "sha512-An6+yUSrOStQSpZwKW9XN891kCW6eagtuofyudZ2BkoxcYRJ0vcDXo7RoiXuf9nHaG4k/xwhAzTqe8hdO1ltWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.1",
+        "@turf/bbox": "7.3.1",
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/explode": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/isolines": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-7.3.1.tgz",
+      "integrity": "sha512-TcwbTd7Z4BffYe1PtpXUtZvWCwTffta8VxqryGU30CbqKjNJYqrFbEQXS0mo4l3BEPPmT1lfMskUQ2g97O2MWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/jsts": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@turf/jsts/-/jsts-2.7.2.tgz",
+      "integrity": "sha512-zAezGlwWHPyU0zxwcX2wQY3RkRpwuoBmhhNE9HY9kWhFDkCxZ3aWK5URKwa/SWKJbj9aztO+8vtdiBA28KVJFg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "dependencies": {
+        "jsts": "2.7.1"
+      }
+    },
+    "node_modules/@turf/kinks": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-7.3.1.tgz",
+      "integrity": "sha512-gGXNrhlF7zvLwRX672S0Be7bmYjbZEoZYnOGN6RvhyBFSSLFIbne+I74I+lWRzAzG/NhAMBXma5TpB09iTH06Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-7.3.1.tgz",
+      "integrity": "sha512-QOr4qS3yi6qWIfQ/KLcy4rDLdemGCYpqz2YDh29R46seE+arSvlBI0KXvI36rPzgEMcUbQuVQyO65sOSqPaEjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-arc": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-7.3.1.tgz",
+      "integrity": "sha512-QSuVP0YWcfl76QjPb5Y2GJqXnziSJ2AuaJm5RKEFt5ELugXdEcHkRtydkGov+ZRPmI93jVmXoEE0UXwQx7aYHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.1",
+        "@turf/destination": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-chunk": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-7.3.1.tgz",
+      "integrity": "sha512-fbJw/7Qlqz0XRMz0TgtFUivFHr51+++ZUBrARgs3w/pogeAdkrcWKBbuT2cowEsUkXDHaQ7MMpmuV8Uteru1qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/length": "7.3.1",
+        "@turf/line-slice-along": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-7.3.1.tgz",
+      "integrity": "sha512-HFPH4Hi+rG7XZ5rijkYL5C9JGVKd6gz6TToShVfqOt/qgGY9/bLYQxymgum/MG7sRhIa8xcKff2d57JrIVuSWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "sweepline-intersections": "^1.5.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-offset": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-7.3.1.tgz",
+      "integrity": "sha512-PyElfSyXETXcI8OKRsAJNdOcxlM718EG0d+b9zeO2uRztf2IlSb5w3lYiTIUSslEDA1gMQE31cJE8sAW40+nhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-overlap": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-7.3.1.tgz",
+      "integrity": "sha512-xIhTfPhJMwz57DvM+/JuzG2BUL/gR/pJfH6w+vofI3akej33LTR8b296h2dhcJjDixxprVVH062AD1Q3AGKyfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-on-line": "7.3.1",
+        "@turf/geojson-rbush": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/line-segment": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/nearest-point-on-line": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "fast-deep-equal": "^3.1.3",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-7.3.1.tgz",
+      "integrity": "sha512-hHz1fM2LigNKmnhyHDXtbRrkBqltH/lYEvhgSmv3laZ9PsEYL8jvA3o7+IhLM9B4KPa8N6VGim6ZR5YA5bhLvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-7.3.1.tgz",
+      "integrity": "sha512-bp1L4sc7ZOYC4fwxpfWu+IR/COvLFGm5mjbLPK8VBJYa+kUNrzNcB3QE3A8yFRjwPtlUTCm5fDMLSoGtiJcy2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/nearest-point-on-line": "7.3.1",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-slice-along": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-7.3.1.tgz",
+      "integrity": "sha512-RizIhPytHxEewCyUCSMrZ5a58sQev0kZ0jzAV/9iTzvGfRD1VU/RG2ThLpSEqXYKBBSty98rTeSlnwsvZpAraA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.1",
+        "@turf/destination": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-split": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-7.3.1.tgz",
+      "integrity": "sha512-Ee4NRN+eYKYX8vJDNvMpyZFjOntKFokQ/E8yFtKMcN++vG7RbnPOo2/ag6TMZaIHsahj4UR2yhqJbHTaB6Dp+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/geojson-rbush": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/line-intersect": "7.3.1",
+        "@turf/line-segment": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/nearest-point-on-line": "7.3.1",
+        "@turf/truncate": "7.3.1",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-to-polygon": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-7.3.1.tgz",
+      "integrity": "sha512-GL4fjbdYYjfOmwTu4dtllNHm18E7+hoXqyca2Rqb2ZzXj++NHvifJ9iYHUSdpV4/mkvVD3U2rU6jzNkjQeXIaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/mask": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-7.3.1.tgz",
+      "integrity": "sha512-rSNS6wNuBiaUR1aU7tobgkzHpot5v9GKCn+n5gQ3ad7KWqwwqLWfcCPeyHBWkWEoEwc2yfPqikMQugZbmxrorg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.1.tgz",
+      "integrity": "sha512-NWsfOE5RVtWpLQNkfOF/RrYvLRPwwruxhZUV0UFIzHqfiRJ50aO9Y6uLY4bwCUe2TumLJQSR4yaoA72Rmr2mnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/midpoint": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-7.3.1.tgz",
+      "integrity": "sha512-hx3eT9ut0Qyl8fyitCREp9l+v5Q4uBILht5+VKQS3p5eK2ijLEsKw4VikNZhh2rZ7bHGrs6obG5/P5ZqDTObiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.1",
+        "@turf/destination": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/moran-index": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/moran-index/-/moran-index-7.3.1.tgz",
+      "integrity": "sha512-9t70AjBB0bycJWLVprqS7mtRU+Ha+U4ji5lkKzyg31ZWAr0IwuawY2VQ/ydsodFMLCqmIf8QbWsltV/I/bRdjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance-weight": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-neighbor-analysis": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-neighbor-analysis/-/nearest-neighbor-analysis-7.3.1.tgz",
+      "integrity": "sha512-qwZON/7v1NbD1H1v3kTHJfLLml2/TNj5QQFRFBJiXRSCydMJT1sKEs5BwJe/9cBbmd0ln3gBWXCkG7Sk3sPgOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.1",
+        "@turf/bbox": "7.3.1",
+        "@turf/bbox-polygon": "7.3.1",
+        "@turf/centroid": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/nearest-point": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-7.3.1.tgz",
+      "integrity": "sha512-hLKGFzwAEop5z04X5BeurJvz0oVPHQX0rjeL3v83kgIjR/eavQucXKO3XkJBoF1AaT9Dv0mgB8rmj/qrwroWgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.1.tgz",
+      "integrity": "sha512-FialyHfXXZWLayKQcUtdOtKv3ulOQ9FSI45kSmkDl8b96+VFWHX983Pc94tTrSTSg89+XX7MDr6gRl0yowmF4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-to-line": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-7.3.1.tgz",
+      "integrity": "sha512-7zvhE15vlKBW7F3gYmxZMrnsS2HhXIt0Mpdymy6Y1oMWAXrYIqSeHl1Y/h2CiDh0v91K1KJXf2WyRYacosWiNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/point-to-line-distance": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/planepoint": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-7.3.1.tgz",
+      "integrity": "sha512-/DVTAZcOsSW54B9XDYUXyiL000vJ8WfONCF4FoM71VMeLS7PM3e+4W9gzN21q15XRn3nUftH12tJhqKEqDouvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-grid": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-7.3.1.tgz",
+      "integrity": "sha512-KqBlGgBzI/M7/awK25o9p8Q+mRjQDRU4mpHtqNzqNxgidk4JxnUnGybYTnsjp3n1Zid3yASv5kARJ4i/Jc5F7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-within": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-on-feature": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-7.3.1.tgz",
+      "integrity": "sha512-uX15wjujBMeMKAN7OLK4RV6KCLxsoQiFRB9kMtbTeZj13mDo+Bz5SyNN+M2AXqrdsQI9+4h0UTwu3EjcXj/nEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/center": "7.3.1",
+        "@turf/explode": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/nearest-point": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-line-distance": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-7.3.1.tgz",
+      "integrity": "sha512-vynnX3zIMmJY633fyAIKnzlsmL7OBhbk05YhWVSjCKvSQV8C2xMA9pWaLFacn1xu4nfMSVDUaNOrcAqwubN9pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/nearest-point-on-line": "7.3.1",
+        "@turf/projection": "7.3.1",
+        "@turf/rhumb-bearing": "7.3.1",
+        "@turf/rhumb-distance": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/point-to-polygon-distance": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-polygon-distance/-/point-to-polygon-distance-7.3.1.tgz",
+      "integrity": "sha512-A2hTQjMKO2VEMdgOariICLCjt0BDc1wAQ7Mzqc4vFuol1/GlAed4JqyLg1zXuOVlZcojvXDk/XRuZwXDlRJkBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/point-to-line-distance": "7.3.1",
+        "@turf/polygon-to-line": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/points-within-polygon": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-7.3.1.tgz",
+      "integrity": "sha512-tVcQVykc1vvSqz+l/PA4EKVWfMrGtA3ZUxDYBoD2tSaM79EpdTcY1BzfxT5O2582SQ0AdNFXDXRTf7VI6u/+2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-smooth": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-smooth/-/polygon-smooth-7.3.1.tgz",
+      "integrity": "sha512-CNi4SdpOycZRSBr4o0MlrFdC6x5xcXP6jKx2yXZf9FPrOWamHsDXa+NrywCOAPhgZKnBodRF6usKWudVMyPIgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-tangents": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-7.3.1.tgz",
+      "integrity": "sha512-XPLeCLQAcU2xco+3kS5Mp4AKmCKjOGzyZoC6oy8BuvHg1HaaEs0ZRzcmf0x17cq7bruhJ7n/QkcudnAueae5mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/boolean-within": "7.3.1",
+        "@turf/explode": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/nearest-point": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-7.3.1.tgz",
+      "integrity": "sha512-qTOFzn7SLQ0TcKBsPFAFYz7iiq34ijqinpjyr9fHQlFHRHeWzUXiWyIn5a2uOHazkdhHCEXNX8JPkt6hjdZ/fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygonize": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-7.3.1.tgz",
+      "integrity": "sha512-BSamH4eDSbREtye/RZiIyt488KI/hO3+2FiDB8JUoHNESe3VNWk4KEy+sL6oqfhOZcRWndHtJ6MOi3HFptyJrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/envelope": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-7.3.1.tgz",
+      "integrity": "sha512-nDM3LG2j37B1tCpF4xL4rUBrQJcG585IRyDIxL2QEvP1LLv6dcm4fodw70HcGAj05Ux8bJr7IOXQXnobOJrlRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/quadrat-analysis": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/quadrat-analysis/-/quadrat-analysis-7.3.1.tgz",
+      "integrity": "sha512-Kwqtih5CnijULGoTobS0pXdzh/Yr3iGatJcKks4IaxA4+hlJ6Z+Mj47QfKvUtl/IP3lZpVzezewJ51Y989YtVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.1",
+        "@turf/bbox": "7.3.1",
+        "@turf/bbox-polygon": "7.3.1",
+        "@turf/centroid": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/point-grid": "7.3.1",
+        "@turf/random": "7.3.1",
+        "@turf/square-grid": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/random": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-7.3.1.tgz",
+      "integrity": "sha512-Iruica0gfdAuuqWG3SLe1MQOEP4IOGelPp81Cu552AamhHJmkEZCaiis2n28qdOlAbDs1NJZeJhRFNkiopiy+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rectangle-grid": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/rectangle-grid/-/rectangle-grid-7.3.1.tgz",
+      "integrity": "sha512-3/fwd1dzeGApxGXAzyVINFylmn8trYTPLG6jtqOgriAdiHPMTtPqSW58wpScC43oKbK3Bps9dSZ43jvcbrfGxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-intersects": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rewind": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-7.3.1.tgz",
+      "integrity": "sha512-gD2TGPNq3SE6IlpDwkVHQthZ2U2MElh6X4Vfld3K7VsBHJv4eBct6OOgSWZLkVVPHuWNlVFTNtcRh2LAznMtgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-clockwise": "7.3.1",
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-bearing": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-7.3.1.tgz",
+      "integrity": "sha512-GA/EUSOMapLp6qK5kOX+PkFg2MMUHzUSm/jVezv6Fted0dAlCgXHOrKgLm0tN8PqbH7Oj9xQhv9+3/1ze7W8YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-destination": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-7.3.1.tgz",
+      "integrity": "sha512-HjtAFr5DTISUn9b4oaZpX79tYl72r4EyAj40HKwjQeV6KkwIe5/h4zryOSEpnvAK2Gnkmu1GxYeTGfM5z3J9JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/rhumb-distance": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-7.3.1.tgz",
+      "integrity": "sha512-9ZvXU0ii2aywdphLhiawl3uxMEHucMmXCBiRj3WhmssTY9CZkFii9iImbJEqz5glxh6/gzXDcz1CCFQUdNP2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sample": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-7.3.1.tgz",
+      "integrity": "sha512-s9IkXrrtaHRllgk9X2tmg8+SJKLG6orQwf0p1wZX8WxnHXvmnHaju465A3nmtGGVDI/RSD8KwU9aqPcc4AinNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/sector": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-7.3.1.tgz",
+      "integrity": "sha512-3BYJk7pQaqVr1Ji1ors6FUnhCJVHuobNf4bYW2yAUW1rxL+snuo6aTCsu39hpkwLj4BBknYt5w4MIOy5b8+QKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/circle": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/line-arc": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/shortest-path": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-7.3.1.tgz",
+      "integrity": "sha512-B0j6MoTSeGw1inRJPfj+6lU4WVXBNFAafqs/BkccScnCHLLK+vMnsOkyQoDX2vdZnhPTEaGj7TEL1SIjV6IMgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/bbox-polygon": "7.3.1",
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/clean-coords": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/transform-scale": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/simplify": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-7.3.1.tgz",
+      "integrity": "sha512-8LRITQAyNAdvVInjm8pal3J7ZAZZBYrYd5oApXqHlIFK7gEiE21Hx9CZyog6AHDjxZCinwnEoGkzDxORh/mNMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clean-coords": "7.3.1",
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-7.3.1.tgz",
+      "integrity": "sha512-LvMkII6bbHaFHp67jI029xHjWFK3pnqwF8c2pUNU+0dL+45KgrO2jaFTnNQdsjexPymI+uaNLlG809Y0aGGQlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/square-grid": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-7.3.1.tgz",
+      "integrity": "sha512-WYCX8+nrqHyAhKBSBHFp1eU1gWrcojz9uVvhCbDO8NO14SLHowzWOgB61Gv8KlLXCUBjDr+rYWCt3ymyPzU5TA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/rectangle-grid": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/standard-deviational-ellipse": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-7.3.1.tgz",
+      "integrity": "sha512-u9ojpWyv3rnFioYZyya6VXVDrRPYymNROVKwGqnQzffYE1MdxhJ6ik/CvdcChzCNvSNVBJQUvnjjPq2C2uOsLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/center-mean": "7.3.1",
+        "@turf/ellipse": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/points-within-polygon": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tag": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-7.3.1.tgz",
+      "integrity": "sha512-Y7G2EWm0/j78ss5wCnjGWKfmPbXw9yKJFg93EuMnwggIsDfKdQi/vdUInjQ0462RIQA87StlydPG09X/8bquwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tesselate": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-7.3.1.tgz",
+      "integrity": "sha512-iJnatp9RcJvyffBjqJaw5GbKE/PQosT8DH2kgG7pv4Re0xl3h/QvCjvTlCTEmJ5cNY4geZVKUXDvkkCkgQQVuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "earcut": "^2.2.4",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/tin": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-7.3.1.tgz",
+      "integrity": "sha512-pDtHE8rLXvV4zAC9mWmwToDDda2ZTty8IZqZIoUqTnlf6AJjzF7TJrhoE3a+zukRTUI1wowTFqe2NvwgNX0yew==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-rotate": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-7.3.1.tgz",
+      "integrity": "sha512-KAYebOkk7IT2j7S8M+ZxDAmyqeni9ZZGU9ouD6mvd/hTpDOlGG+ORRmg312RxG0NiThzCHLyeG1Nea1nEud6bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/centroid": "7.3.1",
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/rhumb-bearing": "7.3.1",
+        "@turf/rhumb-destination": "7.3.1",
+        "@turf/rhumb-distance": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-scale": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-7.3.1.tgz",
+      "integrity": "sha512-e8jBSWEn0BMxG0HR8ZMvkHgBgdwNrFRzbhy8DqQwZDgUN59fMeWGbjX5QR5Exl2gZBPaBXkgbDgEhh/JD3kYhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "7.3.1",
+        "@turf/center": "7.3.1",
+        "@turf/centroid": "7.3.1",
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/rhumb-bearing": "7.3.1",
+        "@turf/rhumb-destination": "7.3.1",
+        "@turf/rhumb-distance": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/transform-translate": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-7.3.1.tgz",
+      "integrity": "sha512-yeaW1EqfuuY4l5VBWSsItglaZ9qdTFD0QEIUW1ooOYuQvtKQ2MTKrcQIKLXZckxQrrNq4TXsZDaBbFs+U1wtcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/rhumb-destination": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/triangle-grid": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-7.3.1.tgz",
+      "integrity": "sha512-lhZyqnQC/M8x8DgQURHNZP/HaJIqrL5We5ZvzJBX+lrH2u4DO831awJcuDniRuJ5e0QE5n4yMsBJO77KMNdKfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/intersect": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/truncate": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-7.3.1.tgz",
+      "integrity": "sha512-rcXHM2m17hyKoW1dJpOvTgUUWFOKluTKKsoLmhEE6aRAYwtuVetkcInt4qBtS1bv7MaL//glbvq0kdEGR0YaOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/turf": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.3.1.tgz",
+      "integrity": "sha512-0uKkNnM6Bo6cIzZcJ6wQ+FjFioTFXWS3woGDvQ5R7EPehNfdr4HTS39m1seE+HdI8lGItMZehb6fb0jtjP4Clg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/along": "7.3.1",
+        "@turf/angle": "7.3.1",
+        "@turf/area": "7.3.1",
+        "@turf/bbox": "7.3.1",
+        "@turf/bbox-clip": "7.3.1",
+        "@turf/bbox-polygon": "7.3.1",
+        "@turf/bearing": "7.3.1",
+        "@turf/bezier-spline": "7.3.1",
+        "@turf/boolean-clockwise": "7.3.1",
+        "@turf/boolean-concave": "7.3.1",
+        "@turf/boolean-contains": "7.3.1",
+        "@turf/boolean-crosses": "7.3.1",
+        "@turf/boolean-disjoint": "7.3.1",
+        "@turf/boolean-equal": "7.3.1",
+        "@turf/boolean-intersects": "7.3.1",
+        "@turf/boolean-overlap": "7.3.1",
+        "@turf/boolean-parallel": "7.3.1",
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/boolean-point-on-line": "7.3.1",
+        "@turf/boolean-touches": "7.3.1",
+        "@turf/boolean-valid": "7.3.1",
+        "@turf/boolean-within": "7.3.1",
+        "@turf/buffer": "7.3.1",
+        "@turf/center": "7.3.1",
+        "@turf/center-mean": "7.3.1",
+        "@turf/center-median": "7.3.1",
+        "@turf/center-of-mass": "7.3.1",
+        "@turf/centroid": "7.3.1",
+        "@turf/circle": "7.3.1",
+        "@turf/clean-coords": "7.3.1",
+        "@turf/clone": "7.3.1",
+        "@turf/clusters": "7.3.1",
+        "@turf/clusters-dbscan": "7.3.1",
+        "@turf/clusters-kmeans": "7.3.1",
+        "@turf/collect": "7.3.1",
+        "@turf/combine": "7.3.1",
+        "@turf/concave": "7.3.1",
+        "@turf/convex": "7.3.1",
+        "@turf/destination": "7.3.1",
+        "@turf/difference": "7.3.1",
+        "@turf/dissolve": "7.3.1",
+        "@turf/distance": "7.3.1",
+        "@turf/distance-weight": "7.3.1",
+        "@turf/ellipse": "7.3.1",
+        "@turf/envelope": "7.3.1",
+        "@turf/explode": "7.3.1",
+        "@turf/flatten": "7.3.1",
+        "@turf/flip": "7.3.1",
+        "@turf/geojson-rbush": "7.3.1",
+        "@turf/great-circle": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/hex-grid": "7.3.1",
+        "@turf/interpolate": "7.3.1",
+        "@turf/intersect": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@turf/isobands": "7.3.1",
+        "@turf/isolines": "7.3.1",
+        "@turf/kinks": "7.3.1",
+        "@turf/length": "7.3.1",
+        "@turf/line-arc": "7.3.1",
+        "@turf/line-chunk": "7.3.1",
+        "@turf/line-intersect": "7.3.1",
+        "@turf/line-offset": "7.3.1",
+        "@turf/line-overlap": "7.3.1",
+        "@turf/line-segment": "7.3.1",
+        "@turf/line-slice": "7.3.1",
+        "@turf/line-slice-along": "7.3.1",
+        "@turf/line-split": "7.3.1",
+        "@turf/line-to-polygon": "7.3.1",
+        "@turf/mask": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@turf/midpoint": "7.3.1",
+        "@turf/moran-index": "7.3.1",
+        "@turf/nearest-neighbor-analysis": "7.3.1",
+        "@turf/nearest-point": "7.3.1",
+        "@turf/nearest-point-on-line": "7.3.1",
+        "@turf/nearest-point-to-line": "7.3.1",
+        "@turf/planepoint": "7.3.1",
+        "@turf/point-grid": "7.3.1",
+        "@turf/point-on-feature": "7.3.1",
+        "@turf/point-to-line-distance": "7.3.1",
+        "@turf/point-to-polygon-distance": "7.3.1",
+        "@turf/points-within-polygon": "7.3.1",
+        "@turf/polygon-smooth": "7.3.1",
+        "@turf/polygon-tangents": "7.3.1",
+        "@turf/polygon-to-line": "7.3.1",
+        "@turf/polygonize": "7.3.1",
+        "@turf/projection": "7.3.1",
+        "@turf/quadrat-analysis": "7.3.1",
+        "@turf/random": "7.3.1",
+        "@turf/rectangle-grid": "7.3.1",
+        "@turf/rewind": "7.3.1",
+        "@turf/rhumb-bearing": "7.3.1",
+        "@turf/rhumb-destination": "7.3.1",
+        "@turf/rhumb-distance": "7.3.1",
+        "@turf/sample": "7.3.1",
+        "@turf/sector": "7.3.1",
+        "@turf/shortest-path": "7.3.1",
+        "@turf/simplify": "7.3.1",
+        "@turf/square": "7.3.1",
+        "@turf/square-grid": "7.3.1",
+        "@turf/standard-deviational-ellipse": "7.3.1",
+        "@turf/tag": "7.3.1",
+        "@turf/tesselate": "7.3.1",
+        "@turf/tin": "7.3.1",
+        "@turf/transform-rotate": "7.3.1",
+        "@turf/transform-scale": "7.3.1",
+        "@turf/transform-translate": "7.3.1",
+        "@turf/triangle-grid": "7.3.1",
+        "@turf/truncate": "7.3.1",
+        "@turf/union": "7.3.1",
+        "@turf/unkink-polygon": "7.3.1",
+        "@turf/voronoi": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/union": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-7.3.1.tgz",
+      "integrity": "sha512-Fk8HvP2gRrRJz8xefeoFJJUeLwhih3HoPPKlqaDf/6L43jwAzBD6BPu59+AwRXOlaZeOUMNMGzgSgx0KKrBwBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "polyclip-ts": "^0.16.8",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/unkink-polygon": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-7.3.1.tgz",
+      "integrity": "sha512-6NVFkCpJUT2P4Yf3z/FI2uGDXqVdEqZqKGl2hYitmH7mNiKhU4bAvvcw7nCSfNG3sUyNhibbtOEopYMRgwimPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/area": "7.3.1",
+        "@turf/boolean-point-in-polygon": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/meta": "7.3.1",
+        "@types/geojson": "^7946.0.10",
+        "rbush": "^3.0.1",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/voronoi": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-7.3.1.tgz",
+      "integrity": "sha512-yS+0EDwSIOizEXI+05qixw/OGZalpfsz9xzBWbCBA3Gu2boLMXErFZ73qzfu39Vwk+ILbu5em0p+VhULBzvH9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/clone": "7.3.1",
+        "@turf/helpers": "7.3.1",
+        "@turf/invariant": "7.3.1",
+        "@types/d3-voronoi": "^1.1.12",
+        "@types/geojson": "^7946.0.10",
+        "d3-voronoi": "1.1.2",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3184,6 +5214,12 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-voronoi": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@types/d3-voronoi/-/d3-voronoi-1.1.12.tgz",
+      "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3218,6 +5254,7 @@
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -3235,6 +5272,7 @@
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3245,6 +5283,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3380,6 +5419,7 @@
       "integrity": "sha512-aIFPci9xoTmVkxpqsSKcRG/Hn0lTy421jsCehHydYeIMd+getn0Pue0JqY5cW8yZglZjMeX0YfIy5wDtQDHEcA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.7",
         "fflate": "^0.8.2",
@@ -3485,6 +5525,15 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.25.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
@@ -3505,6 +5554,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -3698,6 +5748,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/concaveman": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.2.1.tgz",
+      "integrity": "sha512-PwZYKaM/ckQSa8peP5JpVr7IMJ4Nn/MHIaWUjP4be+KoZ7Botgs8seAZGpmaOM+UZXawcdYRao/px9ycrCihHw==",
+      "license": "ISC",
+      "dependencies": {
+        "point-in-polygon": "^1.1.0",
+        "rbush": "^3.0.1",
+        "robust-predicates": "^2.0.4",
+        "tinyqueue": "^2.0.3"
+      }
+    },
     "node_modules/confbox": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
@@ -3773,6 +5835,27 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha512-RhGS1u2vavcO7ay7ZNAPo4xeDh/VYeGof3x5ZLJBQgYhLegxr3s5IykvWmJ94FTU6mcbtp4sloqZ54mP6R4Utw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/data-urls": {
       "version": "6.0.0",
@@ -3880,6 +5963,12 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.211",
@@ -4006,6 +6095,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -4042,6 +6137,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geojson-equality-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-equality-ts/-/geojson-equality-ts-1.0.2.tgz",
+      "integrity": "sha512-h3Ryq+0mCSN/7yLs0eDgrZhvc9af23o/QuC4aTiuuzP/MRCtd6mf5rLsLRY44jX0RPUfM8c4GqERQmlUxPGPoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.14"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-polygon-self-intersections/-/geojson-polygon-self-intersections-1.2.1.tgz",
+      "integrity": "sha512-/QM1b5u2d172qQVO//9CGRa49jEmclKEsYOQmWP9ooEjj63tBM51m2805xsbxkzlEELQ2REgTf700gUhhlegxA==",
+      "license": "MIT",
+      "dependencies": {
+        "rbush": "^2.0.1"
+      }
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/quickselect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
+      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==",
+      "license": "ISC"
+    },
+    "node_modules/geojson-polygon-self-intersections/node_modules/rbush": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.2.tgz",
+      "integrity": "sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^1.0.1"
       }
     },
     "node_modules/get-caller-file": {
@@ -4225,6 +6353,7 @@
       "integrity": "sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.19",
         "@asamuzakjp/dom-selector": "^6.7.3",
@@ -4292,11 +6421,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsts": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
+      "integrity": "sha512-x2wSZHEBK20CY+Wy+BPE7MrFQHW6sIsdaGUMEqmGAio+3gFzQaBYPwLRonUfQf9Ak8pBieqj9tUofX1+WtAEIg==",
+      "license": "(EDL-1.0 OR EPL-1.0)",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/lightningcss": {
       "version": "1.30.1",
@@ -4648,6 +6787,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -4825,6 +6965,37 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
+    },
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/point-in-polygon-hao/node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
+    "node_modules/polyclip-ts": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/polyclip-ts/-/polyclip-ts-0.16.8.tgz",
+      "integrity": "sha512-JPtKbDRuPEuAjuTdhR62Gph7Is2BS1Szx69CFOO3g71lpJDFo78k4tFyi+qFOMVPePEzdSKkpGU3NBXPHHjvKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.1.0",
+        "splaytree-ts": "^1.0.2"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -4878,11 +7049,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4913,6 +7100,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4925,6 +7113,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
       "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5115,6 +7304,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.50.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
@@ -5239,6 +7434,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
+      "license": "MIT"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -5257,6 +7458,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/splaytree-ts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
+      "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
+      "license": "BDS-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -5349,6 +7556,15 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sweepline-intersections": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sweepline-intersections/-/sweepline-intersections-1.5.0.tgz",
+      "integrity": "sha512-AoVmx72QHpKtItPu72TzFL+kcYjd67BPLDoR0LarIk+xyaRg+pDTMFXndIEvZf9xEKnJv6JdhgRMnocoG0D3AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyqueue": "^2.0.0"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -5469,6 +7685,12 @@
         "node": "^18.0.0 || >=20.0.0"
       }
     },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
+    },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
@@ -5507,6 +7729,44 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.17.tgz",
       "integrity": "sha512-DieYoGrP78PWKsrXr8MZwtQ7GLCUeLxihtjC1jZsW1DnvSMdKPitJSe8OSYDM2u5H6g3kWJZpePqkp43TfLh0g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/topojson-server": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.1.tgz",
+      "integrity": "sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "geo2topo": "bin/geo2topo"
+      }
+    },
+    "node_modules/topojson-server/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/totalist": {
@@ -5584,6 +7844,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -5633,6 +7894,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5760,30 +8022,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/ultracite/node_modules/@vitest/ui": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
-      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "fflate": "^0.8.2",
-        "flatted": "^3.3.3",
-        "pathe": "^2.0.3",
-        "sirv": "^3.0.1",
-        "tinyglobby": "^0.2.14",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "vitest": "3.2.4"
-      }
-    },
     "node_modules/ultracite/node_modules/@vitest/utils": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
@@ -5839,6 +8077,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -6011,6 +8250,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
       "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -6126,6 +8366,7 @@
       "integrity": "sha512-xQroKAadK503CrmbzCISvQUjeuvEZzv6U0wlnlVFOi5i3gnzfH4onyQ29f3lzpe0FresAiTAd3aqK0Bi/jLI8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.7",
         "@vitest/mocker": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/vite": "^4.1.12",
     "@tanstack/react-query": "^5.87.1",
     "@tanstack/react-table": "^8.21.3",
+    "@turf/turf": "^7.3.1",
     "@types/leaflet": "^1.9.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/dashboard/map-legend.tsx
+++ b/src/components/dashboard/map-legend.tsx
@@ -2,9 +2,10 @@ import { AlertTriangle, Truck } from 'lucide-react'
 
 type MapLegendProps = {
   routeColor: string
+  showUncovered?: boolean
 }
 
-export function MapLegend({ routeColor }: MapLegendProps) {
+export function MapLegend({ routeColor, showUncovered }: MapLegendProps) {
   return (
     <div className="absolute bottom-2 left-2 z-[1000] rounded-lg border bg-card/95 p-3 shadow-lg backdrop-blur-sm">
       <h4 className="mb-2 font-semibold text-muted-foreground text-xs">
@@ -42,6 +43,12 @@ export function MapLegend({ routeColor }: MapLegendProps) {
           />
           <span className="text-xs">Trajeto</span>
         </div>
+        {showUncovered && (
+          <div className="flex items-center gap-2">
+            <div className="h-4 w-4 border border-red-500 bg-red-500/40" />
+            <span className="text-xs">Área não percorrida</span>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/dashboard/route-map.tsx
+++ b/src/components/dashboard/route-map.tsx
@@ -8,6 +8,7 @@ import {
   Popup,
   TileLayer,
   useMap,
+  GeoJSON,
 } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import { format } from 'date-fns'
@@ -15,13 +16,16 @@ import { ptBR } from 'date-fns/locale'
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
 import markerIcon2x from 'leaflet/dist/images/marker-icon-2x.png'
 import markerShadow from 'leaflet/dist/images/marker-shadow.png'
-import { RotateCcw } from 'lucide-react'
+import { RotateCcw, Eye, EyeOff } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { useRouteAnimation } from '@/hooks/use-route-animation'
 import type { TrajetoComPontos } from '@/http/trajeto/types'
+import { useGetAreasNaoPercorridas } from '@/http/rotas/use-get-areas-nao-percorridas'
 import { AnimationControls } from './animation-controls'
 import { MapLegend } from './map-legend'
+import * as turf from '@turf/turf'
+import type { FeatureCollection, Polygon, MultiPolygon } from 'geojson'
 
 // @ts-expect-error - Leaflet icon fix
 L.Icon.Default.prototype._getIconUrl = undefined
@@ -129,6 +133,64 @@ function ResetMapView({ center, zoom }: ResetMapViewProps) {
   )
 }
 
+type UncoveredAreasControlProps = {
+  isActive: boolean
+  onToggle: () => void
+  isLoading: boolean
+}
+
+function UncoveredAreasControl({
+  isActive,
+  onToggle,
+  isLoading,
+}: UncoveredAreasControlProps) {
+  // Prevent click/drag propagation to the map
+  const handleContainerClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+  }
+
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onToggle()
+  }
+
+  return (
+    <div
+      className="leaflet-top leaflet-left"
+      style={{ marginTop: '10px', marginLeft: '50px', zIndex: 1000 }}
+      onClick={handleContainerClick}
+      onDoubleClick={handleContainerClick}
+      onMouseDown={handleContainerClick}
+    >
+      <div className="leaflet-control leaflet-bar">
+        <Button
+          className={`h-[30px] px-3 rounded-sm shadow-md transition-colors ${
+            isActive
+              ? 'bg-white text-destructive hover:bg-gray-50 border-destructive border'
+              : 'bg-white text-gray-700 hover:bg-gray-50'
+          }`}
+          onClick={handleButtonClick}
+          size="sm"
+          title={
+            isActive
+              ? 'Ocultar áreas não percorridas pelo caminhão'
+              : 'Exibir áreas não percorridas pelo caminhão'
+          }
+        >
+          {isActive ? (
+            <EyeOff className="h-4 w-4 mr-2" />
+          ) : (
+            <Eye className="h-4 w-4 mr-2" />
+          )}
+          <span className="text-xs font-medium">
+            {isLoading ? 'Carregando...' : 'Ver Locais Não Percorridos'}
+          </span>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
 type RouteMapProps = {
   trajeto: TrajetoComPontos
 }
@@ -136,6 +198,55 @@ type RouteMapProps = {
 export function RouteMap({ trajeto }: RouteMapProps) {
   const { pontos, incidentes = [] } = trajeto
   const [speed, setSpeed] = useState(100)
+  const [showUncovered, setShowUncovered] = useState(false)
+
+  const { data: areasNaoPercorridas, isLoading: isLoadingAreas } =
+    useGetAreasNaoPercorridas(trajeto.rotaId, trajeto.id, {
+      enabled: showUncovered,
+      refetchInterval: trajeto.status === 'EM_ANDAMENTO' ? 5000 : false,
+    })
+
+  const processedUncoveredAreas = useMemo(() => {
+    if (
+      !showUncovered ||
+      !areasNaoPercorridas?.areas_nao_cobertas ||
+      !pontos ||
+      pontos.length < 2
+    ) {
+      return areasNaoPercorridas?.areas_nao_cobertas
+    }
+
+    try {
+      // Create LineString from points (Long, Lat) for Turf
+      const lineCoords = pontos.map((p) => [p.longitude, p.latitude])
+      const line = turf.lineString(lineCoords)
+
+      // Buffer the route by 20 meters (0.02 km) to simulate truck coverage
+      const routeBuffer = turf.buffer(line, 0.02, { units: 'kilometers' })
+
+      // Prepare Area Feature from backend GeoJSON Geometry
+      const rawGeometry = areasNaoPercorridas.areas_nao_cobertas
+      // Ensure it's a Feature for Turf
+      const areaFeature =
+        rawGeometry.type === 'Feature'
+          ? rawGeometry
+          : { type: 'Feature', properties: {}, geometry: rawGeometry }
+
+      // Calculate Difference: Area - RouteBuffer
+      // turf.difference(featureCollection([poly1, poly2])) -> subtracts poly2 from poly1
+      const collection = turf.featureCollection([
+        areaFeature,
+        routeBuffer,
+      ]) as FeatureCollection<Polygon | MultiPolygon>
+      
+      const result = turf.difference(collection)
+
+      return result
+    } catch (error) {
+      console.error('Error calculating uncovered areas difference:', error)
+      return areasNaoPercorridas.areas_nao_cobertas
+    }
+  }, [showUncovered, areasNaoPercorridas, pontos])
 
   const animation = useRouteAnimation({ pontos, speed })
 
@@ -197,6 +308,24 @@ export function RouteMap({ trajeto }: RouteMapProps) {
           />
 
           <ResetMapView center={center} zoom={15} />
+          <UncoveredAreasControl
+            isActive={showUncovered}
+            isLoading={isLoadingAreas}
+            onToggle={() => setShowUncovered(!showUncovered)}
+          />
+
+          {showUncovered && processedUncoveredAreas && (
+            <GeoJSON
+              data={processedUncoveredAreas}
+              key={JSON.stringify(processedUncoveredAreas)}
+              style={{
+                color: '#ef4444',
+                weight: 1,
+                fillColor: '#ef4444',
+                fillOpacity: 0.4,
+              }}
+            />
+          )}
 
           <Polyline
             color={routeColor}
@@ -335,7 +464,7 @@ export function RouteMap({ trajeto }: RouteMapProps) {
           )}
         </MapContainer>
 
-        <MapLegend routeColor={routeColor} />
+        <MapLegend routeColor={routeColor} showUncovered={showUncovered} />
       </div>
 
       <AnimationControls

--- a/src/http/rotas/use-get-areas-nao-percorridas.ts
+++ b/src/http/rotas/use-get-areas-nao-percorridas.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiConfig, fetchWithAuth } from '@/services/api'
+
+export interface EstatisticasCobertura {
+  area_total_m2: number
+  area_coberta_m2: number
+  area_nao_coberta_m2: number
+  percentual_cobertura: number
+  quantidade_trajetos: number
+  cobertura_completa: boolean
+  status_cobertura: string
+}
+
+export interface AreasNaoPercorridasDTO {
+  rota_id: number
+  rota_nome: string
+  // biome-ignore lint/suspicious/noExplicitAny: GeoJSON structure varies
+  areas_nao_cobertas: any
+  estatisticas: EstatisticasCobertura
+  buffer_metros: number
+}
+
+async function getAreasNaoPercorridas(
+  rotaId: number,
+  trajetoId?: number
+): Promise<AreasNaoPercorridasDTO> {
+  const url = new URL(
+    `${apiConfig.baseUrl}${apiConfig.endpoints.rotas.naoPercorridas(rotaId)}`
+  )
+  if (trajetoId) {
+    url.searchParams.append('trajetoId', String(trajetoId))
+  }
+  
+  const response = await fetchWithAuth(url.toString())
+  return response.json()
+}
+
+export function useGetAreasNaoPercorridas(
+  rotaId: number | undefined,
+  trajetoId?: number,
+  options?: { enabled?: boolean; refetchInterval?: number | false }
+) {
+  return useQuery({
+    queryKey: ['areas-nao-percorridas', rotaId, trajetoId],
+    queryFn: () => getAreasNaoPercorridas(rotaId!, trajetoId),
+    enabled: !!rotaId && (options?.enabled ?? true),
+    refetchInterval: options?.refetchInterval,
+  })
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -38,6 +38,7 @@ export const apiConfig = {
     rotas: {
       list: '/rota',
       byId: (id: number) => `/rota/${id}`,
+      naoPercorridas: (id: number) => `/rota/${id}/nao-percorridas`,
     },
     trajetos: {
       list: '/trajetos',


### PR DESCRIPTION
Tem o botao novo Ver Locais Não Percorridos, e sua versão contrário para não Ver a area que ele renderiza, ele pega a area total da rota renderiza em vermelho transparente o que não foi percorrido dessa area, então se tiver um trajeto que passa pela area da rota vinculada a ele, essa area fica limpa. Tem que testar para saber se é isso mesmo, para mim faz sentido da maneira como está, mas tem muitos trajetos com pontos sem sentido que não ajudam a testar. O Trajeto de 11/11 de 1h53m ajuda a perceber. ja tem outro do dia 24 de novembro 22:49 em andamento que tem 138898 pontos, esse literalmente está travando o servidor por causa de tanto ponto na tela.